### PR TITLE
Add coveralls.io support

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,0 +1,1 @@
+service_name: travis-ci

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,8 +1,15 @@
 module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-contrib-requirejs');
   grunt.loadNpmTasks('grunt-karma');
+  grunt.loadNpmTasks('grunt-karma-coveralls');
 
   grunt.initConfig({
+    coveralls: {
+      options: {
+        coverage_dir: 'coverage/'
+      }
+    },
+
     karma: {
       options: {
         configFile: 'config/karma.conf.js'
@@ -25,7 +32,16 @@ module.exports = function(grunt) {
         }
       },
       travis: {
-        browsers: ['PhantomJS']
+        singleRun: true,
+        reporters: ['dots', 'coverage'],
+        browsers: ['PhantomJS'],
+        preprocessors: {
+          'src/*.js': 'coverage'
+        },
+        coverageReporter: {
+          type : 'lcov',
+          dir : 'coverage/'
+        }
       }
     },
 
@@ -78,5 +94,5 @@ module.exports = function(grunt) {
   grunt.registerTask('build', 'Builds files for production', ['requirejs:build-minified', 'requirejs:build-unminified']);
 
   // Travis CI task
-  grunt.registerTask('travis', 'Travis CI task', ['karma:travis']);
+  grunt.registerTask('travis', 'Travis CI task', ['karma:travis', 'coveralls']);
 };

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![Build Status](https://travis-ci.org/tagged/infinite-scroll.png)](https://travis-ci.org/tagged/infinite-scroll)
 [![Dependency Status](https://gemnasium.com/tagged/infinite-scroll.png)](https://gemnasium.com/tagged/infinite-scroll)
+[![Coverage Status](https://coveralls.io/repos/tagged/infinite-scroll/badge.png)](https://coveralls.io/r/tagged/infinite-scroll)
 
 Infinite Scroll for AngularJS
 =============================

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "grunt": "~0.4.2",
     "grunt-contrib-requirejs": "~0.4.1",
     "grunt-karma": "~0.6.2",
+    "grunt-karma-coveralls": "~2.0.2",
     "karma": "~0.10.6",
     "karma-chai": "0.0.2",
     "karma-chrome-launcher": "~0.1.1",


### PR DESCRIPTION
Uses [grunt-karma-coveralls](https://github.com/mattjmorrison/grunt-karma-coveralls) to generate coverage statistics and pipe them to [coveralls.io/r/tagged/infinite-scroll](https://coveralls.io/r/tagged/infinite-scroll).

New Badge
[![Coverage Status](https://coveralls.io/repos/tagged/infinite-scroll/badge.png?branch=coveralls)](https://coveralls.io/r/tagged/infinite-scroll?branch=coveralls)
