### PR TITLE
[demo] Enable the autoscroll module on the demo page by default

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -92,6 +92,7 @@ function InfiniteScrollDemoController($scope, $timeout) {
   $scope.items = [];
   $scope.distance = 0;
   $scope.paginating = false;
+  $scope.enabled = true;
 
   // This is called each time the infinite scroll directive needs to get more items.
   // This dummy implementation simply adds fake items to `$scope.items` and limits


### PR DESCRIPTION
Auto enables the infinite scroll module when you first load the page to make it more intuitive.

When I clicked the demo link, I was a little confused as to why it didn't work when I scrolled to the bottom.
