### PR TITLE
Move angular-mocks to devDependencies

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,8 +20,10 @@
   ],
   "dependencies": {
     "angular": "~1.2.3",
-    "angular-mocks": "~1.2.3",
     "jquery": "1.10.2",
     "underscore": "~1.5.2"
+  },
+  "devDependencies": {
+    "angular-mocks": "~1.2.3"
   }
 }


### PR DESCRIPTION
It is only needed for running tests and pollutes index.html when using bower-install.
