### PR TITLE
Remove the dead badge for gemnasium

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 [![Build Status](https://travis-ci.org/tagged/infinite-scroll.png)](https://travis-ci.org/tagged/infinite-scroll)
-[![Dependency Status](https://gemnasium.com/tagged/infinite-scroll.png)](https://gemnasium.com/tagged/infinite-scroll)
 [![Coverage Status](https://coveralls.io/repos/tagged/infinite-scroll/badge.png)](https://coveralls.io/r/tagged/infinite-scroll)
 
 # Infinite Scroll for AngularJS


### PR DESCRIPTION
GitHub now includes scanning of insecure dependencies that are reported to organization members, this is no longer necessary.

See https://docs.gitlab.com/ee/user/project/import/gemnasium.html for reintroduction instructions (optional)