### PR TITLE
npm-shrinkwrap.json should not be published in a lib

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1085,9 +1085,9 @@
                   "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.2.1.tgz"
                 },
                 "i": {
-                  "version": "0.3.2",
+                  "version": "0.3.3",
                   "from": "i@0.3.x",
-                  "resolved": "https://registry.npmjs.org/i/-/i-0.3.2.tgz"
+                  "resolved": "https://registry.npmjs.org/i/-/i-0.3.3.tgz"
                 },
                 "mkdirp": {
                   "version": "0.5.0",


### PR DESCRIPTION
(see https://docs.npmjs.com/files/shrinkwrap.json)

Moving npm-shrinkwrap.json to package-lock.json
Fixes #20 